### PR TITLE
Add LLM prompt builder and heuristic mix analysis

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -131,7 +131,11 @@ def compute_time_based_metrics(y, sr, window_sec=0.2, clip_threshold=0.99):
         dyn_range_raw.append(peak_val - rms_val)
         mid = 0.5 * (L + R); side = 0.5 * (L - R)
         mid_side.append(np.sum(side**2) / (np.sum(mid**2) + 1e-9))
-        stereo_corr.append(float(np.corrcoef(L, R)[0, 1]) if len(L) > 1 else 1.0)
+        if len(L) > 1 and len(R) > 1:
+            corr_val = np.corrcoef(L, R)[0, 1]
+        else:
+            corr_val = 1.0
+        stereo_corr.append(float(np.nan_to_num(corr_val, nan=0.0, posinf=0.0, neginf=0.0)))
     return np.array(times), np.array(sub_bass), np.array(clipping), np.array(dyn_range_raw), np.array(mid_side), np.array(stereo_corr)
 
 def compute_summary_stats(arr):
@@ -183,6 +187,308 @@ def default_converter(o):
     if isinstance(o, np.ndarray):
         return o.tolist()
     raise TypeError(f"Object of type {type(o)} is not JSON serializable")
+
+def analyze_mix_health(baseline, compound, sub_bass, clipping, dyn_range_raw, mid_side, stereo_corr):
+    """Derive heuristic mix observations for LLM prompt building."""
+
+    def _safe_array(arr):
+        if arr is None:
+            return np.array([])
+        cleaned = np.asarray(arr, dtype=float)
+        if cleaned.ndim == 0:
+            cleaned = cleaned.reshape(1)
+        return cleaned
+
+    arr_sub = _safe_array(sub_bass)
+    arr_clipping = _safe_array(clipping)
+    arr_dyn = _safe_array(dyn_range_raw)
+    arr_mid_side = _safe_array(mid_side)
+    arr_stereo = np.nan_to_num(_safe_array(stereo_corr), nan=0.0, posinf=0.0, neginf=0.0)
+
+    issues = []
+    strengths = []
+
+    def add_issue(severity, text):
+        issues.append({"severity": severity, "text": text})
+
+    def add_strength(text):
+        strengths.append(text)
+
+    def safe_stat(arr, func, fallback=None):
+        if arr.size == 0:
+            return fallback
+        value = func(arr)
+        if np.isnan(value):
+            return fallback
+        return float(value)
+
+    # Windowed statistics
+    clip_windows_ratio = safe_stat(arr_clipping > 0, np.mean, 0.0)
+    total_clipped_samples = int(np.sum(arr_clipping)) if arr_clipping.size else 0
+    sub_bass_mean = safe_stat(arr_sub, np.mean)
+    mid_side_mean = safe_stat(arr_mid_side, np.mean)
+    stereo_corr_mean = safe_stat(arr_stereo, np.mean)
+    dyn_range_mean = safe_stat(arr_dyn, np.mean)
+
+    # Headroom & clipping
+    peak_db = baseline.get('peak_db', 0.0)
+    if clip_windows_ratio and clip_windows_ratio > 0:
+        severity = "High" if clip_windows_ratio > 0.1 or baseline.get('peak', 0) >= 0.999 else "Moderate"
+        add_issue(severity, f"Detected {total_clipped_samples} clipped samples across analysis windows (peak level {peak_db:.2f} dBFS).")
+    else:
+        add_strength(f"No clipping detected; peak level sits at {peak_db:.2f} dBFS.")
+
+    # Crest factor & dynamics
+    crest_db = baseline.get('crest_db')
+    if crest_db is not None:
+        crest_db = float(crest_db)
+        if crest_db < 6:
+            add_issue("High", f"Crest factor is {crest_db:.1f} dB, indicating restricted punch (typical mixes land around 8–14 dB).")
+        elif crest_db < 8:
+            add_issue("Moderate", f"Crest factor is {crest_db:.1f} dB; consider restoring a bit more transient headroom.")
+        elif 8 <= crest_db <= 14:
+            add_strength(f"Crest factor of {crest_db:.1f} dB sits in a healthy mix range.")
+
+    if dyn_range_mean is not None:
+        if dyn_range_mean is not None and dyn_range_mean < 0.05:
+            add_issue("High", f"Average peak-to-RMS window range is {dyn_range_mean:.3f}, suggesting heavy limiting.")
+        elif dyn_range_mean is not None and dyn_range_mean < 0.1:
+            add_issue("Moderate", f"Average peak-to-RMS window range is {dyn_range_mean:.3f}; dynamics are a bit constrained.")
+        elif dyn_range_mean and dyn_range_mean > 0.25:
+            add_strength(f"Windowed peak-to-RMS range averages {dyn_range_mean:.3f}, retaining good punch.")
+
+    # Spectral balance
+    low_mid_ratio = baseline.get('low_mid_ratio')
+    if low_mid_ratio is not None:
+        low_mid_ratio = float(low_mid_ratio)
+        if low_mid_ratio > 1.6:
+            add_issue("Moderate", f"Low frequencies dominate the mids (low/mid ratio {low_mid_ratio:.2f}).")
+        elif low_mid_ratio < 0.6:
+            add_issue("Moderate", f"Low frequencies trail the mids (low/mid ratio {low_mid_ratio:.2f}).")
+        elif 0.8 <= low_mid_ratio <= 1.2:
+            add_strength(f"Low and mid energy stay balanced (ratio {low_mid_ratio:.2f}).")
+
+    mid_high_ratio = baseline.get('mid_high_ratio')
+    if mid_high_ratio is not None:
+        mid_high_ratio = float(mid_high_ratio)
+        if mid_high_ratio > 1.6:
+            add_issue("Moderate", f"Midrange leans forward of highs (mid/high ratio {mid_high_ratio:.2f}).")
+        elif mid_high_ratio < 0.6:
+            add_issue("Moderate", f"Top end outweighs the mids (mid/high ratio {mid_high_ratio:.2f}).")
+        elif 0.8 <= mid_high_ratio <= 1.2:
+            add_strength(f"Mid and high balance looks even (ratio {mid_high_ratio:.2f}).")
+
+    # Stereo behavior
+    if sub_bass_mean is not None:
+        if sub_bass_mean < 0.5:
+            add_issue("High", f"Sub-bass mono compatibility averages {sub_bass_mean:.2f}; expect cancellations when summed to mono.")
+        elif sub_bass_mean < 0.7:
+            add_issue("Moderate", f"Sub-bass mono compatibility averages {sub_bass_mean:.2f}; consider tightening lows.")
+        elif sub_bass_mean > 0.9:
+            add_strength(f"Sub-bass mono compatibility is excellent (mean {sub_bass_mean:.2f}).")
+
+    if mid_side_mean is not None:
+        if mid_side_mean > 1.5:
+            add_issue("Moderate", f"Mid/side energy ratio averages {mid_side_mean:.2f}; the sides dominate the stereo field.")
+        elif mid_side_mean < 0.5:
+            add_issue("Moderate", f"Mid/side energy ratio averages {mid_side_mean:.2f}; the mix may feel narrow.")
+        else:
+            add_strength(f"Mid/side energy ratio {mid_side_mean:.2f} keeps the stereo image balanced.")
+
+    if stereo_corr_mean is not None:
+        if stereo_corr_mean < 0.2:
+            add_issue("High", f"Average stereo correlation is {stereo_corr_mean:.2f}; check for phase issues.")
+        elif stereo_corr_mean < 0.6:
+            add_issue("Moderate", f"Average stereo correlation is {stereo_corr_mean:.2f}; the image may drift or collapse in mono.")
+        elif stereo_corr_mean > 0.8:
+            add_strength(f"Stereo correlation averages {stereo_corr_mean:.2f}, showing cohesive left/right behavior.")
+
+    # Loudness indicators
+    rms_db = baseline.get('rms_db')
+    if rms_db is not None:
+        rms_db = float(rms_db)
+        if rms_db > -8:
+            add_issue("Moderate", f"RMS level sits at {rms_db:.1f} dBFS; watch that headroom isn't exhausted before mastering.")
+        elif rms_db < -26:
+            add_issue("Moderate", f"RMS level sits at {rms_db:.1f} dBFS; consider raising the mix bus if noise allows.")
+
+    integrated_loudness = baseline.get('integrated_loudness')
+    if integrated_loudness is not None:
+        loudness_val = float(integrated_loudness)
+        if loudness_val > -10:
+            add_issue("High", f"Integrated loudness is {loudness_val:.1f} LUFS, above typical streaming limits (aim ≈ -14 LUFS).")
+        elif loudness_val < -20:
+            add_issue("Moderate", f"Integrated loudness is {loudness_val:.1f} LUFS, quieter than most references (aim ≈ -14 LUFS).")
+        else:
+            add_strength(f"Integrated loudness at {loudness_val:.1f} LUFS is in the streaming-ready window.")
+
+    # Compound scores
+    clarity = compound.get('Clarity')
+    if clarity is not None:
+        clarity = float(clarity)
+        if clarity < 0.5:
+            add_issue("Moderate", f"Clarity score is {clarity:.2f}; transient definition may need attention.")
+        elif clarity > 0.7:
+            add_strength(f"Clarity score of {clarity:.2f} suggests well-defined transients.")
+
+    quality = compound.get('Quality')
+    if quality is not None:
+        quality = float(quality)
+        if quality < 0.5:
+            add_issue("Moderate", f"Quality score is {quality:.2f}; harmonic noise balance could be improved.")
+        elif quality > 0.7:
+            add_strength(f"Quality score of {quality:.2f} indicates a clean harmonic profile.")
+
+    derived = {
+        "clipped_window_pct": clip_windows_ratio * 100 if clip_windows_ratio is not None else None,
+        "total_clipped_samples": total_clipped_samples,
+        "sub_bass_mean": sub_bass_mean,
+        "mid_side_mean": mid_side_mean,
+        "stereo_corr_mean": stereo_corr_mean,
+        "window_dynamic_range_mean": dyn_range_mean,
+        "crest_db": crest_db,
+        "rms_db": rms_db,
+    }
+
+    if integrated_loudness is not None:
+        derived['integrated_loudness'] = float(integrated_loudness)
+
+    return {
+        "issues": issues,
+        "strengths": strengths,
+        "derived": derived
+    }
+
+def build_llm_prompt(export_data, health_summary):
+    """Create a structured prompt string for downstream LLM analysis."""
+
+    file_info = export_data.get("file_info", {})
+    baseline = export_data.get("baseline_metrics", {})
+    compound = export_data.get("compound_metrics", {})
+    time_summary = export_data.get("time_based_metrics", {}).get("summary", {})
+
+    baseline_aQi = export_data.get("baseline_aQi")
+    time_aQi = export_data.get("time_aQi")
+    final_aQi = export_data.get("final_aQi")
+
+    def fmt_number(value):
+        if value is None:
+            return "N/A"
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            return str(value)
+        if abs(value) >= 1000 or (abs(value) > 0 and abs(value) < 0.001):
+            return f"{value:.3e}"
+        if abs(value) >= 100:
+            return f"{value:.1f}"
+        return f"{value:.3f}"
+
+    prompt_lines = [
+        "You are a seasoned mixing and mastering engineer. Review the supplied diagnostics and provide targeted mix guidance.",
+        ""
+    ]
+
+    channels = file_info.get("channels")
+    sample_rate = file_info.get("sample_rate")
+    duration = file_info.get("duration_sec")
+    mix_snapshot = " - ".join(
+        [
+            part for part in [
+                f"Channels: {channels}" if channels is not None else None,
+                f"Sample rate: {sample_rate} Hz" if sample_rate is not None else None,
+                f"Duration: {duration:.1f} s" if isinstance(duration, (int, float)) else None,
+            ] if part is not None
+        ]
+    )
+    if mix_snapshot:
+        prompt_lines.extend(["### Mix Snapshot", f"- {mix_snapshot}", ""])
+
+    if baseline_aQi is not None and time_aQi is not None and final_aQi is not None:
+        prompt_lines.append(f"- Baseline aQi: {baseline_aQi:.1f}% | Time-Based aQi: {time_aQi:.1f}% | Final aQi: {final_aQi:.1f}%")
+    elif baseline_aQi is not None:
+        prompt_lines.append(f"- Baseline aQi: {baseline_aQi:.1f}%")
+
+    issues = health_summary.get("issues", [])
+    strengths = health_summary.get("strengths", [])
+
+    prompt_lines.append("")
+    prompt_lines.append("### Notable Observations")
+    if issues:
+        for item in issues:
+            severity = item.get("severity", "Info")
+            text = item.get("text", "")
+            prompt_lines.append(f"- [{severity}] {text}")
+    else:
+        prompt_lines.append("- No major technical issues were flagged by heuristics; verify with critical listening.")
+
+    if strengths:
+        prompt_lines.append("")
+        prompt_lines.append("### Strengths to Preserve")
+        for text in strengths:
+            prompt_lines.append(f"- {text}")
+
+    key_baseline = {
+        "RMS (dBFS)": baseline.get("rms_db"),
+        "Peak (dBFS)": baseline.get("peak_db"),
+        "Crest Factor (dB)": baseline.get("crest_db"),
+        "Spectral Centroid": baseline.get("centroid"),
+        "Spectral Flatness": baseline.get("flatness"),
+        "Low/Mid Ratio": baseline.get("low_mid_ratio"),
+        "Mid/High Ratio": baseline.get("mid_high_ratio"),
+        "Dynamic Range (raw)": baseline.get("dynamic_range_raw"),
+        "Integrated Loudness (LUFS)": baseline.get("integrated_loudness"),
+    }
+
+    prompt_lines.append("")
+    prompt_lines.append("### Key Baseline Metrics")
+    for label, value in key_baseline.items():
+        prompt_lines.append(f"- {label}: {fmt_number(value)}")
+
+    prompt_lines.append("")
+    prompt_lines.append("### Time-Based Metrics (200 ms windows)")
+    for metric_name, stats in time_summary.items():
+        mean_val = stats.get("mean")
+        median_val = stats.get("median")
+        max_val = stats.get("max")
+        min_val = stats.get("min")
+        prompt_lines.append(
+            f"- {metric_name}: mean {fmt_number(mean_val)} | median {fmt_number(median_val)} | min {fmt_number(min_val)} | max {fmt_number(max_val)}"
+        )
+
+    if compound:
+        prompt_lines.append("")
+        prompt_lines.append("### Compound Scores (0–1)")
+        for name, value in compound.items():
+            prompt_lines.append(f"- {name}: {fmt_number(value)}")
+
+    derived = health_summary.get("derived", {})
+    if derived:
+        label_map = {
+            "clipped_window_pct": "Windows with clipping (%)",
+            "total_clipped_samples": "Total clipped samples",
+            "sub_bass_mean": "Sub-bass mono mean",
+            "mid_side_mean": "Mid/side ratio mean",
+            "stereo_corr_mean": "Stereo correlation mean",
+            "window_dynamic_range_mean": "Window peak–RMS mean",
+            "crest_db": "Crest factor (dB)",
+            "rms_db": "RMS (dBFS)",
+            "integrated_loudness": "Integrated loudness (LUFS)",
+        }
+        prompt_lines.append("")
+        prompt_lines.append("### Derived Indicators")
+        for key, label in label_map.items():
+            if key in derived:
+                prompt_lines.append(f"- {label}: {fmt_number(derived.get(key))}")
+
+    prompt_lines.append("")
+    prompt_lines.append("### Requested LLM Output")
+    prompt_lines.append("1. Summarize the mix health, referencing the most relevant metrics above.")
+    prompt_lines.append("2. Recommend high-impact mix adjustments (EQ, dynamics, stereo, balance) that address the flagged issues.")
+    prompt_lines.append("3. Suggest final loudness and dynamic targets suited for mainstream streaming platforms unless specified otherwise.")
+    prompt_lines.append("4. List any additional checks the producer should run before handing the mix to a mastering engineer.")
+
+    return "\n".join(prompt_lines)
 
 ####################################
 # Main App
@@ -289,11 +595,13 @@ if uploaded_file is not None:
           - *Dynamic Range (raw):* Computed as (peak - RMS) and normalized by an ideal scale (adjusted here to 0.5).
           - *Mid/Side Ratio:* Normalized as 1 – |avg – 1| (ideal = 1).
           - *Stereo Correlation:* Average correlation (normalized 0–1).
-          
+
         The final aQi is the mean of these two values.
         """)
-    
-    # Export Data
+
+    health_summary = analyze_mix_health(baseline, compound, sub_bass, clipping, dyn_range_raw, mid_side, stereo_corr)
+
+    # Export Data & Prompting
     st.header("Export Metrics for AI Analysis")
     target_shape = (100,100)
     S_db_summary = spectrogram_summary(S_db, target_shape=target_shape)
@@ -345,8 +653,38 @@ if uploaded_file is not None:
             "The final aQi is the mean of these two values."
         )
     }
-    
+
+    export_data["time_aQi"] = time_aQi
+    export_data["final_aQi"] = final_aQi
+    export_data["health_summary"] = health_summary
+
+    prompt_text = build_llm_prompt(export_data, health_summary)
+    export_data["llm_prompt_template"] = prompt_text
+
     export_json = json.dumps(export_data, default=default_converter, indent=2)
+
+    st.subheader("LLM Prompt Builder")
+    col_issues, col_strengths = st.columns(2)
+    with col_issues:
+        st.markdown("**Flagged Issues**")
+        if health_summary["issues"]:
+            for item in health_summary["issues"]:
+                st.write(f"- [{item['severity']}] {item['text']}")
+        else:
+            st.write("- No major issues detected by heuristics.")
+    with col_strengths:
+        st.markdown("**Strengths**")
+        if health_summary["strengths"]:
+            for text in health_summary["strengths"]:
+                st.write(f"- {text}")
+        else:
+            st.write("- No specific strengths flagged.")
+
+    st.markdown("Copy or download the prompt below to brief your LLM co-pilot:")
+    st.code(prompt_text, language="markdown")
+    st.download_button(label="Download LLM Prompt", data=prompt_text, file_name="mix_prompt.md", mime="text/markdown")
+
+    st.subheader("Raw Data Exports")
     st.download_button(label="Export Metrics as JSON",
                        data=export_json,
                        file_name="audio_metrics.json",


### PR DESCRIPTION
## Summary
- add heuristic mix analysis helpers that interpret baseline and time-window metrics for downstream LLM use
- generate a structured prompt template and expose it inside the Streamlit app alongside flagged issues and strengths
- include the new prompt and health summary in exported JSON and stabilize stereo correlation measurements

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68c8984395fc8323963b37152e2c3e0f